### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # repl-ba272
 Repo for storing repl's for BA 272 at Oregon State University
+[![Run on Repl.it](https://repl.it/badge/github/clementsm-cob/repl-ba272)](https://repl.it/github/clementsm-cob/repl-ba272)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@MarkClements/repl-ba272).